### PR TITLE
Added MEFS tab word break CSS

### DIFF
--- a/dist/css/umb-bi-css-main.css
+++ b/dist/css/umb-bi-css-main.css
@@ -553,6 +553,17 @@ th {
     box-shadow: 0 1px 1px -1px rgba(0,0,0,0.4);
 }
 
+/* ---------------------- GLOSS TAB WORD BREAK OVERRIDE FROM MEFS ----------- */
+li.tab-break-all {
+    -ms-word-break: break-all;
+    word-break: break-all;
+    
+}
+
+li.tab-break-word {
+    word-break: break-word;
+}
+
 
 /* ---------------------- DATA BLOCK SECTION ---------------------- */
 .title-block {


### PR DESCRIPTION
Word break CSS added to override Gloss tab, utilized in MEFS left hand navigation.