### PR TITLE
whitespace no wrap

### DIFF
--- a/dist/css/umb-bi-css-main-dark.css
+++ b/dist/css/umb-bi-css-main-dark.css
@@ -108,6 +108,7 @@ body {
 
 .nav-item {
     width: 100%;
+    white-space: nowrap;
 }
 
 /* .nav-item:nth-last-child(2) {

--- a/dist/css/umb-bi-css-main.css
+++ b/dist/css/umb-bi-css-main.css
@@ -87,6 +87,7 @@ body {
 
 .nav-item {
     width: 100%;
+    white-space: nowrap;
 }
 
 /* .nav-item:nth-last-child(2) {


### PR DESCRIPTION
This CSS property disables nav items on the main left-side menu from wrapping as the menu expands.